### PR TITLE
New sort method for food_vec_

### DIFF
--- a/environment.cpp
+++ b/environment.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <algorithm>
+#include <algorithm> //inplace_merge()
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
@@ -136,10 +136,18 @@ void Environment::feeding(){
     uint16_t y = rand() % testground_size_;
     food_vec_.push_back(make_pair(x,y));
   }
+  sort(food_vec_.end() - food_count,food_vec_.end());
+  std::inplace_merge(food_vec_.begin(), food_vec_.end() - food_count, food_vec_.end());
+  // if(tick_ == 100){
+  //   for (size_t i = 0; i < food_vec_.size(); ++i) {
+  //     std::cout << food_vec_[i].first << "   " << food_vec_[i].second << "\n";
+  //   }
+  //   std::cout << "------------" << '\n';
+  // }
 }
 
 void Environment::searchFood(){
-  sort(food_vec_.begin(), food_vec_.end());
+  // sort(food_vec_.begin(), food_vec_.end());
   if (debug || debug_env) {
     for (size_t i = 0; i < food_vec_.size(); ++i) {
       cout << "(" << food_vec_[i].first << "," << food_vec_[i].first << ")\n";

--- a/util.cpp
+++ b/util.cpp
@@ -5,6 +5,10 @@
 
 using namespace std;
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 extern bool debug; // "extern" tells the compiler that debug is already declared somewhere else (environment.cpp)
 bool debug_util = false;
 


### PR DESCRIPTION
Instead of sorting the food vector every time in searchFood() all over, I changed it so, that only new food sources get sorted, when inserted. There were two options for this:
- Insert every new foodsource at the correct position in the vector one after each other
- Create all new food sources, sort only them and then merge the old and the new foodsources

I implemented both and measured the times with openmp (100000 ticks):
```
master: 900 secs
insert: 992 secs
merge: 885 secs
```
Obviously the insert method didn't help. The merge method was a little bit faster

Also defined M_PI as it wasn't defined on my device for some reason. The definition is save with 
`#ifdef M_PI` 
So if it's already defined e.g. in <math.h> there won't be a double definition